### PR TITLE
Modify the response to match GraphQL's standard format

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,7 @@ app.prepare()
       }
 
       return graphql(schema, graphqlQuery)
-        .then(response => response.data)
-        .then(data => res.json(data))
+      .then(({ data, errors }) => res.json({ data, errors }))
         .catch(err => console.error(err)); // eslint-disable-line no-console
     });
 


### PR DESCRIPTION
I was having troubles making Apollo Client to work with the `/graphql` endpoint, then I realised the response doesn't match [the standard GraphQL response format](https://facebook.github.io/graphql/June2018/#sec-Response-Format):

```
{
	data: {...},
	errors: [...],
}
```